### PR TITLE
Fix compilation error

### DIFF
--- a/include/pistache/http_headers.h
+++ b/include/pistache/http_headers.h
@@ -32,7 +32,7 @@ bool LowercaseEqualStatic(const std::string& dynamic, const std::string& statik)
 
 struct LowercaseEqual {
     bool operator()(const std::string& left, const std::string& right) const {
-        return std::equal(left.begin(), left.end(), right.begin(), right.end(),
+        return std::equal(left.begin(), left.end(), right.begin(),
             [] (const char& a, const char& b) {
                 return std::tolower(a) == std::tolower(b);
             });


### PR DESCRIPTION
std::equal takes 3 iterators or 3 iterators and a predicate function