### PR TITLE
Fix compilation error

### DIFF
--- a/src/common/http_headers.cc
+++ b/src/common/http_headers.cc
@@ -43,7 +43,7 @@ toLowercase(std::string str) {
 
 bool
 LowercaseEqualStatic(const std::string& dynamic, const std::string& statik) {
-    return std::equal(dynamic.begin(), dynamic.end(), statik.begin(), statik.end(),
+    return std::equal(dynamic.begin(), dynamic.end(), statik.begin(),
         [] (const char& a, const char& b) {
             return std::tolower(a) == b;
         });


### PR DESCRIPTION
std::equal takes 3 iterators or 3 iterators and a predicate function